### PR TITLE
fix: cloudflare image 404 + add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zubair Khalid
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # personal-website
 
-Astro 6 personal site — portfolio at `/`, MDX blog at `/blog`.
+Portfolio and blog
 
 ## Dev
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,3 +1,4 @@
+import cloudflare from '@astrojs/cloudflare';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
@@ -5,8 +6,6 @@ import { defineConfig, fontProviders } from 'astro/config';
 import icon from 'astro-icon';
 import { siteUrl } from './src/data/site';
 import { remarkReadingTime } from './src/lib/remark-reading-time';
-
-import cloudflare from '@astrojs/cloudflare';
 
 export default defineConfig({
   site: siteUrl,
@@ -48,5 +47,5 @@ export default defineConfig({
     },
   ],
 
-  adapter: cloudflare(),
+  adapter: cloudflare({ imageService: 'compile' }),
 });

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "personal-website",
   "type": "module",
   "version": "0.0.1",
+  "license": "MIT",
   "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=22"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,17 +5,9 @@
     "exactOptionalPropertyTypes": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["src/*"]
     }
   },
-  "include": [
-    ".astro/types.d.ts",
-    "**/*",
-    "./worker-configuration.d.ts"
-  ],
-  "exclude": [
-    "dist"
-  ]
+  "include": [".astro/types.d.ts", "**/*", "./worker-configuration.d.ts"],
+  "exclude": ["dist"]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,25 +1,25 @@
 {
-	"compatibility_date": "2026-04-16",
-	"compatibility_flags": ["global_fetch_strictly_public"],
-	"name": "personal-website",
-	"main": "@astrojs/cloudflare/entrypoints/server",
-	"assets": {
-		"directory": "./dist",
-		"binding": "ASSETS"
-	},
-	"observability": {
-		"enabled": false,
-		"head_sampling_rate": 1,
-		"logs": {
-			"enabled": true,
-			"head_sampling_rate": 1,
-			"persist": true,
-			"invocation_logs": true
-		},
-		"traces": {
-			"enabled": false,
-			"persist": true,
-			"head_sampling_rate": 1
-		}
-	}
+  "compatibility_date": "2026-04-16",
+  "compatibility_flags": ["global_fetch_strictly_public"],
+  "name": "personal-website",
+  "main": "@astrojs/cloudflare/entrypoints/server",
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS"
+  },
+  "observability": {
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": false,
+      "persist": true,
+      "head_sampling_rate": 1
+    }
+  }
 }


### PR DESCRIPTION
- Fix `/_image?...` 404 on Cloudflare deployment by switching the adapter's image service to `compile`. Astro 6's `@astrojs/cloudflare` defaults to `cloudflare-binding`, which requires a Cloudflare Images binding that isn't provisioned here. With `compile`, Sharp pre-builds optimized variants at build time and no runtime endpoint is needed.
- Add an MIT license so the project can be forked and reused as a personal-website template; sets `"license": "MIT"` in `package.json`.