### PR TITLE
fix: pagefind 404 + scope giscus to production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "lefthook install",
     "dev": "astro dev",
     "build": "astro build",
-    "postbuild": "pagefind --site dist",
+    "postbuild": "pagefind --site dist/client",
     "preview": "pnpm run build && wrangler dev",
     "check": "astro check",
     "astro": "astro",

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -32,7 +32,8 @@ const giscusRepo = /^[^/\s]+\/[^/\s]+$/.test(rawGiscusRepo)
 const giscusRepoId = import.meta.env.PUBLIC_GISCUS_REPO_ID;
 const giscusCategory = import.meta.env.PUBLIC_GISCUS_CATEGORY;
 const giscusCategoryId = import.meta.env.PUBLIC_GISCUS_CATEGORY_ID;
-const giscusReady = giscusRepo && giscusRepoId && giscusCategory && giscusCategoryId;
+const giscusReady =
+  import.meta.env.PROD && giscusRepo && giscusRepoId && giscusCategory && giscusCategoryId;
 ---
 
 <BaseLayout {...baseProps}>


### PR DESCRIPTION
- Point `pagefind --site` at `dist/client` instead of `dist`. The Cloudflare adapter serves static assets from `dist/client/`, so the previous setup wrote the index to `dist/pagefind/` where the worker couldn't reach it, causing `/pagefind/pagefind-ui.js` and `pagefind-ui.css` to 404 in production.
- Gate the `<Giscus />` component on `import.meta.env.PROD` so local `astro dev` visits don't trigger giscus[bot] to auto-create a discussion with a `localhost` URL embedded in its body. The existing localhost-tagged discussion should be deleted on GitHub once so the next production visit recreates it with the production URL.